### PR TITLE
Test Docker Connection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='integration_tester',
-    version='0.3.0',
+    version='0.5.0',
     description='A Docker based service manager for testing in Python.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Update-0.5.0-Docker-Error-Handling

- Test Docker connection

__Test Docker Connection__
Each time we perform a creation or deletion on a test, we recreate the connection to the Docker service. With this I added testing for connection, this will make sure that if the docker instance is shutdown during the running of the application, we will get appropriate errors.


This update appears to be a lot smaller that I originally thought it would be. I do not think that docker errors need to be explicitly handled as most of the time they are good. In future if we find that any exceptions are not good enough, we can add.
